### PR TITLE
Throttling standard api v2

### DIFF
--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -674,7 +674,7 @@ class HueApi:
         self, entity: dict, light_data: dict, throttle_ms: int
     ) -> bool:
         """Minimalistic form of throttling, only allow updates to a light within a timespan."""
-        
+
         if not throttle_ms:
             return True
 

--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -674,6 +674,9 @@ class HueApi:
         self, entity: dict, light_data: dict, throttle_ms: int
     ) -> bool:
         """Minimalistic form of throttling, only allow updates to a light within a timespan."""
+        
+        if not throttle_ms:
+            return True
 
         prev_data = self._prev_data.get(entity["entity_id"], {})
 
@@ -703,8 +706,6 @@ class HueApi:
 
         # check throttle timestamp so light commands are only sent once every X milliseconds
         # this is to not overload a light implementation in Home Assistant
-        if not throttle_ms:
-            return True
         prev_timestamp = self._timestamps.get(entity["entity_id"], 0)
         cur_timestamp = int(time.time() * 1000)
         time_diff = abs(cur_timestamp - prev_timestamp)

--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import ssl
+import time
 from typing import Any, AsyncGenerator, Optional
 
 import emulated_hue.const as const
@@ -107,6 +108,8 @@ class HueApi:
         self.http_site = None
         self.https_site = None
         self._new_lights = {}
+        self._timestamps = {}
+        self._prev_data = {}
         with open(DESCRIPTION_FILE, encoding="utf-8") as fdesc:
             self._description_xml = fdesc.read()
 
@@ -600,10 +603,21 @@ class HueApi:
     async def __async_light_action(self, entity: dict, request_data: dict) -> None:
         """Translate the Hue api request data to actions on a light entity."""
 
+        light_id = await self.config.async_entity_id_to_light_id(entity["entity_id"])
+        light_conf = await self.config.async_get_light_config(light_id)
+        throttle_ms = light_conf.get("throttle", const.DEFAULT_THROTTLE_MS)
+
         # Construct what we need to send to the service
         data = {const.HASS_ATTR_ENTITY_ID: entity["entity_id"]}
 
         power_on = request_data.get(const.HASS_STATE_ON, True)
+
+        # throttle command to light
+        data_with_power = request_data.copy()
+        data_with_power[const.HASS_STATE_ON] = power_on
+        if not self.__update_allowed(light_id, data_with_power, throttle_ms):
+            return
+
         service = (
             const.HASS_SERVICE_TURN_ON if power_on else const.HASS_SERVICE_TURN_OFF
         )
@@ -643,13 +657,61 @@ class HueApi:
         if const.HUE_ATTR_TRANSITION in request_data:
             # Duration of the transition from the light to the new state
             # is given as a multiple of 100ms and defaults to 4 (400ms).
-            transitiontime = request_data[const.HUE_ATTR_TRANSITION] / 10
+            if request_data[const.HUE_ATTR_TRANSITION] * 100 <= throttle_ms:
+                transitiontime = throttle_ms / 1000
+            else:
+                transitiontime = request_data[const.HUE_ATTR_TRANSITION] / 10
             data[const.HASS_ATTR_TRANSITION] = transitiontime
         else:
-            data[const.HASS_ATTR_TRANSITION] = 0.4
+            data[const.HASS_ATTR_TRANSITION] = (
+                0.4 if throttle_ms <= 400 else throttle_ms / 1000
+            )
 
         # execute service
         await self.hass.async_call_service(const.HASS_DOMAIN_LIGHT, service, data)
+
+    def __update_allowed(
+        self, light_id: str, light_data: dict, throttle_ms: int
+    ) -> bool:
+        """Minimalistic form of throttling, only allow updates to a light within a timespan."""
+
+        prev_data = self._prev_data.get(light_id, {})
+
+        # force to update if power state changed
+        if prev_data.get(const.HASS_STATE_ON, True) != light_data.get(
+            const.HASS_STATE_ON, True
+        ):
+            return True
+        # check if data changed
+        # when not using udp no need to send same light command again
+        if (
+            prev_data.get(const.HUE_ATTR_BRI, 0)
+            == light_data.get(const.HUE_ATTR_BRI, 0)
+            and prev_data.get(const.HUE_ATTR_HUE, 0)
+            == light_data.get(const.HUE_ATTR_HUE, 0)
+            and prev_data.get(const.HUE_ATTR_SAT, 0)
+            == light_data.get(const.HUE_ATTR_SAT, 0)
+            and prev_data.get(const.HUE_ATTR_CT, 0)
+            == light_data.get(const.HUE_ATTR_CT, 0)
+            and prev_data.get(const.HUE_ATTR_XY, [0, 0])
+            == light_data.get(const.HUE_ATTR_XY, [0, 0])
+        ):
+            return False
+
+        self._prev_data[light_id] = light_data.copy()
+
+        # check throttle timestamp so light commands are only sent once every X milliseconds
+        # this is to not overload a light implementation in Home Assistant
+        if not throttle_ms:
+            return True
+        prev_timestamp = self._timestamps.get(light_id, 0)
+        cur_timestamp = int(time.time() * 1000)
+        time_diff = abs(cur_timestamp - prev_timestamp)
+        if time_diff >= throttle_ms:
+            # change allowed only if within throttle limit
+            self._timestamps[light_id] = cur_timestamp
+            return True
+        return False
 
     async def __async_entity_to_hue(
         self, entity: dict, light_config: Optional[dict] = None

--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -677,10 +677,11 @@ class HueApi:
 
         prev_data = self._prev_data.get(light_id, {})
 
-        # force to update if power state changed
-        if prev_data.get(const.HASS_STATE_ON, True) != light_data.get(
+        # force to update if power state changed or no prev_data
+        if not prev_data or prev_data.get(const.HASS_STATE_ON, True) != light_data.get(
             const.HASS_STATE_ON, True
         ):
+            self._prev_data[light_id] = light_data.copy()
             return True
         # check if data changed
         # when not using udp no need to send same light command again

--- a/emulated_hue/config.py
+++ b/emulated_hue/config.py
@@ -145,7 +145,7 @@ class Config:
                 # TODO: find some way to control the actual startup state?
                 "startup": {"configured": True, "mode": "safety"},
             },
-            "entertainment_throttle": 0,
+            "throttle": 0,
         }
         await self.async_set_storage_value("lights", next_light_id, light_config)
         return next_light_id

--- a/emulated_hue/const.py
+++ b/emulated_hue/const.py
@@ -1,5 +1,7 @@
 """Emulated HUE Bridge for HomeAssistant - constants."""
 
+DEFAULT_THROTTLE_MS = 0
+
 HASS_ATTR_BRIGHTNESS = "brightness"
 HASS_ATTR_COLOR_TEMP = "color_temp"
 HASS_ATTR_XY_COLOR = "xy_color"

--- a/emulated_hue/entertainment.py
+++ b/emulated_hue/entertainment.py
@@ -6,6 +6,7 @@ import os
 import time
 
 from emulated_hue.const import (
+    DEFAULT_THROTTLE_MS,
     HASS_ATTR_BRIGHTNESS,
     HASS_ATTR_RGB_COLOR,
     HASS_ATTR_TRANSITION,
@@ -16,7 +17,6 @@ LOGGER = logging.getLogger(__name__)
 
 COLOR_TYPE_RGB = "RGB"
 COLOR_TYPE_XY_BR = "XY Brightness"
-DEFAULT_THROTTLE_MS = 0
 
 
 if os.path.isfile("/usr/local/opt/openssl@1.1/bin/openssl"):
@@ -105,7 +105,7 @@ class EntertainmentAPI:
         # TODO: can we send udp messages to supported lights such as esphome ?
         # For now we simply unpack the entertainment packet and forward
         # individual commands to lights by calling hass services.
-        throttle_ms = light_conf.get("entertainment_throttle", DEFAULT_THROTTLE_MS)
+        throttle_ms = light_conf.get("throttle", DEFAULT_THROTTLE_MS)
         if not self.__update_allowed(light_id, light_data, throttle_ms):
             return
 


### PR DESCRIPTION
This time I've changed comparing logic of new request data to previous one for power toggle on/off:
1. First - there was a bug on initial state change where previous was empty
2. Also I have found that controlling light outside hue emulated bridge could also break this fucntionality.

Now it compares new power on/off state to entity state (I've traced entity life cycle, and before calling hass service it asks hass for state each time, so I can use it...

Don't merge it yet, I'm still testing it. If you have time, test it too. Thanks.