### PR TITLE
add options to specify ports

### DIFF
--- a/emulated_hue/__init__.py
+++ b/emulated_hue/__init__.py
@@ -14,10 +14,17 @@ LOGGER = logging.getLogger(__name__)
 class HueEmulator:
     """Support for local control of entities by emulating a Philips Hue bridge."""
 
-    def __init__(self, data_path: str, hass_url: str, hass_token: str):
+    def __init__(
+        self,
+        data_path: str,
+        hass_url: str,
+        hass_token: str,
+        http_port: int,
+        https_port: int,
+    ):
         """Create an instance of HueEmulator."""
         self._loop = None
-        self._config = Config(self, data_path)
+        self._config = Config(self, data_path, http_port, https_port)
         self._hass = HomeAssistant(url=hass_url, token=hass_token)
         self._api = HueApi(self)
 

--- a/emulated_hue/__main__.py
+++ b/emulated_hue/__main__.py
@@ -51,6 +51,18 @@ if __name__ == "__main__":
     parser.add_argument(
         "--verbose", action="store_true", help="Enable more verbose logging"
     )
+    parser.add_argument(
+        "--http-port",
+        type=int,
+        help="Port to run the HTTP server (for use with reverse proxy, use with care)",
+        default=80,
+    )
+    parser.add_argument(
+        "--https-port",
+        type=int,
+        help="Port to run the HTTPS server (for use with reverse proxy, use with care)",
+        default=443,
+    )
 
     args = parser.parse_args()
     datapath = args.data

--- a/emulated_hue/__main__.py
+++ b/emulated_hue/__main__.py
@@ -55,13 +55,13 @@ if __name__ == "__main__":
         "--http-port",
         type=int,
         help="Port to run the HTTP server (for use with reverse proxy, use with care)",
-        default=80,
+        default=os.getenv("HTTP_PORT", 80),
     )
     parser.add_argument(
         "--https-port",
         type=int,
         help="Port to run the HTTPS server (for use with reverse proxy, use with care)",
-        default=443,
+        default=os.getenv("HTTPS_PORT", 443),
     )
 
     args = parser.parse_args()

--- a/emulated_hue/__main__.py
+++ b/emulated_hue/__main__.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     if args.verbose or os.getenv("VERBOSE", "").strip() == "true":
         logger.setLevel(logging.DEBUG)
 
-    hue = HueEmulator(datapath, url, token)
+    hue = HueEmulator(datapath, url, token, args.http_port, args.https_port)
 
     def on_shutdown(loop):
         """Call on loop shutdown."""

--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -135,8 +135,7 @@ class HueApi:
         self.runner = web.AppRunner(app, access_log=None)
         await self.runner.setup()
 
-        # Create and start the HTTP API on port 80
-        # Port MUST be 80 to maintain compatability with Hue apps
+        # Create and start the HTTP webserver/api
         self.http_site = web.TCPSite(self.runner, port=self.config.http_port)
         try:
             await self.http_site.start()
@@ -156,8 +155,7 @@ class HueApi:
         ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         ssl_context.load_cert_chain(cert_file, key_file)
 
-        # Create and start the HTTPS API on port 443
-        # Port MUST be 443 to maintain compatability with Hue apps
+        # Create and start the HTTPS webserver/API
         self.https_site = web.TCPSite(
             self.runner, port=self.config.https_port, ssl_context=ssl_context
         )

--- a/emulated_hue/config.py
+++ b/emulated_hue/config.py
@@ -27,7 +27,9 @@ DEFAULT_THROTTLE_MS = 0
 class Config:
     """Hold configuration variables for the emulated hue bridge."""
 
-    def __init__(self, hue: HueEmulator, data_path: str):
+    def __init__(
+        self, hue: HueEmulator, data_path: str, http_port: int, https_port: int
+    ):
         """Initialize the instance."""
         self.hue = hue
         self.data_path = data_path
@@ -43,9 +45,14 @@ class Config:
         LOGGER.info("Auto detected listen IP address is %s", self.ip_addr)
 
         # Get the ports that the Hue bridge will listen on
-        # ports are currently hardcoded as Hue apps expect these ports
-        self.http_port = 80
-        self.https_port = 443
+        # ports can be overridden but Hue apps expect ports 80/443
+        # so this is only usefull when running a reverse proxy on the same host
+        self.http_port = http_port
+        self.https_port = https_port
+        if http_port != 80 or https_port != 443:
+            LOGGER.warning(
+                "Non default http/https ports detected. Hue apps require the bridge at the default ports 80/443, use at your own risk."
+            )
 
         mac_addr = str(get_mac_address(ip=self.ip_addr))
         if not mac_addr or len(mac_addr) < 16:


### PR DESCRIPTION
allows running the bridge through a reverse proxy
while some apps might be able to connect to the custom port, official hue apps will always connect to the bridge ip at the default HTTPS port 443 so the reverse proxy should be setup to handle that situation.
