### PR TITLE
Entertainment fix

### DIFF
--- a/emulated_hue/entertainment.py
+++ b/emulated_hue/entertainment.py
@@ -74,7 +74,7 @@ class EntertainmentAPI:
         # use pseudo tty to fix issue with running openssl in docker (expecting tty)
         _, slave = os.openpty()
         self._socket_daemon = await asyncio.create_subprocess_shell(
-            " ".join(args), stdout=asyncio.subprocess.PIPE, stdin=slave, limit=0
+            " ".join(args), stdout=asyncio.subprocess.PIPE, stdin=slave, limit=pktsize
         )
         while not self._interrupted:
             data = await self._socket_daemon.stdout.read(pktsize)

--- a/emulated_hue/entertainment.py
+++ b/emulated_hue/entertainment.py
@@ -54,7 +54,7 @@ class EntertainmentAPI:
         # MDTLS + PSK is not supported very well in native python
         # As a (temporary?) workaround we rely on the OpenSSL executable which is
         # very well supported on all platforms.
-        LOGGER.info("Start HUE Entertainment Service on UDP port 2100.")
+        LOGGER.info("Start HUE Entertainment Service on UDP port 2100. TEST")
         # length of each packet is dependent of how many lights we're serving in the group
         num_lights = len(self.group_details["lights"])
         pktsize = 16 + (9 * num_lights)

--- a/emulated_hue/entertainment.py
+++ b/emulated_hue/entertainment.py
@@ -72,7 +72,8 @@ class EntertainmentAPI:
             "-quiet",
         ]
         # use pseudo tty to fix issue with running openssl in docker (expecting tty)
-        _, slave = os.openpty()
+        # _, slave = os.openpty()
+        slave = os.devnull
         self._socket_daemon = await asyncio.create_subprocess_shell(
             " ".join(args), stdout=asyncio.subprocess.PIPE, stdin=slave, limit=pktsize
         )

--- a/emulated_hue/entertainment.py
+++ b/emulated_hue/entertainment.py
@@ -54,7 +54,7 @@ class EntertainmentAPI:
         # MDTLS + PSK is not supported very well in native python
         # As a (temporary?) workaround we rely on the OpenSSL executable which is
         # very well supported on all platforms.
-        LOGGER.info("Start HUE Entertainment Service on UDP port 2100. TEST")
+        LOGGER.info("Start HUE Entertainment Service on UDP port 2100. TEST2")
         # length of each packet is dependent of how many lights we're serving in the group
         num_lights = len(self.group_details["lights"])
         pktsize = 16 + (9 * num_lights)
@@ -73,7 +73,7 @@ class EntertainmentAPI:
         ]
         # use pseudo tty to fix issue with running openssl in docker (expecting tty)
         # _, slave = os.openpty()
-        slave = os.devnull
+        slave = asyncio.subprocess.PIPE
         self._socket_daemon = await asyncio.create_subprocess_shell(
             " ".join(args), stdout=asyncio.subprocess.PIPE, stdin=slave, limit=pktsize
         )

--- a/emulated_hue/entertainment.py
+++ b/emulated_hue/entertainment.py
@@ -22,7 +22,7 @@ HASS_SENSOR = "binary_sensor.emulated_hue_entertainment_active"
 
 if os.path.isfile("/usr/local/opt/openssl@1.1/bin/openssl"):
     OPENSSL_BIN = "/usr/local/opt/openssl@1.1/bin/openssl"
-elif os.name == "nt":
+elif os.path.isfile("C:/Program Files/Git/usr/bin/openssl.exe"):
     OPENSSL_BIN = "C:/Program Files/Git/usr/bin/openssl.exe"
 else:
     OPENSSL_BIN = "openssl"
@@ -76,8 +76,8 @@ class EntertainmentAPI:
             "-quiet",
         ]
         # NOTE: enable stdin is required for openssl, even if we do not use it.
-        self._socket_daemon = await asyncio.create_subprocess_shell(
-            " ".join(args),
+        self._socket_daemon = await asyncio.create_subprocess_exec(
+            *args,
             stdout=asyncio.subprocess.PIPE,
             stdin=asyncio.subprocess.PIPE,
             limit=pktsize,


### PR DESCRIPTION
final fix for entertainment mode running in docker/HA addon.

Also adds a binary_sensor to indicate if entertainment mode is active so users can do some automation based on it.
While it's not an event, imo it fixes #64 