### PR TITLE
Adapt changes for updated hass client

### DIFF
--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -670,7 +670,7 @@ class HueApi:
             )
 
         # execute service
-        await self.hass.async_call_service(const.HASS_DOMAIN_LIGHT, service, data)
+        await self.hass.call_service(const.HASS_DOMAIN_LIGHT, service, data)
 
     def __update_allowed(
         self, entity: dict, light_data: dict, throttle_ms: int

--- a/emulated_hue/config.py
+++ b/emulated_hue/config.py
@@ -351,7 +351,7 @@ class Config:
             "title": "Emulated HUE Bridge",
             "message": msg,
         }
-        await self.hue.hass.async_call_service(
+        await self.hue.hass.call_service(
             "persistent_notification", "create", msg_details
         )
 
@@ -365,7 +365,7 @@ class Config:
     async def async_disable_link_mode_discovery(self) -> None:
         """Disable link mode discovery (remove notification in hass)."""
         self._link_mode_discovery_key = None
-        await self.hue.hass.async_call_service(
+        await self.hue.hass.call_service(
             "persistent_notification",
             "dismiss",
             {"notification_id": "hue_bridge_link_requested"},

--- a/emulated_hue/entertainment.py
+++ b/emulated_hue/entertainment.py
@@ -56,7 +56,7 @@ class EntertainmentAPI:
         # As a (temporary?) workaround we rely on the OpenSSL executable which is
         # very well supported on all platforms.
         LOGGER.info("Start HUE Entertainment Service on UDP port 2100.")
-        await self.hue.hass.async_set_state(
+        await self.hue.hass.set_state(
             HASS_SENSOR, "on", {"room": self.group_details["name"]}
         )
         # length of each packet is dependent of how many lights we're serving in the group
@@ -100,7 +100,7 @@ class EntertainmentAPI:
         self._interrupted = True
         if self._socket_daemon:
             self._socket_daemon.kill()
-        self.hue.loop.create_task(self.hue.hass.async_set_state(HASS_SENSOR, "off"))
+        self.hue.loop.create_task(self.hue.hass.set_state(HASS_SENSOR, "off"))
         LOGGER.info("HUE Entertainment Service stopped.")
 
     async def __async_process_light_packet(self, light_data, color_space):
@@ -141,7 +141,7 @@ class EntertainmentAPI:
             svc_data[HASS_ATTR_TRANSITION] = throttle_ms / 1000
         else:
             svc_data[HASS_ATTR_TRANSITION] = 0
-        await self.hass.async_call_service("light", "turn_on", svc_data)
+        await self.hass.call_service("light", "turn_on", svc_data)
         self.hass.states[entity_id]["attributes"].update(svc_data)
 
     def __update_allowed(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ python-slugify==4.0.1
 netaddr==0.8.0
 aiorun==2020.12.1
 getmac==0.8.2
-hass-client==0.0.9
+hass-client==0.1.0
 uvloop==0.14.0; sys_platform != 'win32'
 zeroconf==0.28.8
 tzlocal==2.1


### PR DESCRIPTION
I've refactored the Hass client library a bit. It should be more robust now and better handle reconnects.
This PR adopts our code to this new Hass Client release.

closes #88