### PR TITLE
Resolve pairing for Harmony

### DIFF
--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -70,14 +70,29 @@ EXT:
 LOCATION: http://{0}:{1}/description.xml
 SERVER: Linux/3.14.0 UPnP/1.0 IpBridge/1.20.0
 hue-bridgeid: {2}
-ST: uuid:{3}
-USN: uuid:{3}
+ST: {3}
+USN: uuid:{4}
 
 """
 
-        self.upnp_response = (
+        self.upnp_root_response = (
             resp_template.format(
-                config.ip_addr, config.http_port, config.bridge_id, config.bridge_uid
+                config.ip_addr,
+                config.http_port,
+                config.bridge_id,
+                "upnp:rootdevice",
+                f"{config.bridge_uid}::upnp:rootdevice",
+            )
+            .replace("\n", "\r\n")
+            .encode("utf-8")
+        )
+        self.upnp_device_response = (
+            resp_template.format(
+                config.ip_addr,
+                config.http_port,
+                config.bridge_id,
+                "urn:schemas-upnp-org:device:basic:1",
+                config.bridge_uid,
             )
             .replace("\n", "\r\n")
             .encode("utf-8")
@@ -130,11 +145,15 @@ USN: uuid:{3}
                 # because the data object has not been initialized
                 continue
 
-            if "M-SEARCH" in data.decode("utf-8", errors="ignore"):
+            decoded_data = data.decode("utf-8", errors="ignore")
+            if "M-SEARCH" in decoded_data:
                 # SSDP M-SEARCH method received, respond to it with our info
                 resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-                resp_socket.sendto(self.upnp_response, addr)
+                if "upnp:rootdevice" in decoded_data:
+                    resp_socket.sendto(self.upnp_root_response, addr)
+                else:
+                    resp_socket.sendto(self.upnp_device_response, addr)
                 LOGGER.debug("Serving SSDP discovery info to %s", addr)
                 resp_socket.close()
 

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -144,8 +144,7 @@ USN: {bridge_uuid}
                 if decoded_st_field == "ssdp:all":
                     decoded_st_field = "urn:schemas-upnp-org:device:basic:1"
                 else:
-                    # decoded_st_field = f"uuid:{self.config.bridge_uid}"
-                    decoded_st_field = "urn:schemas-upnp-org:device:basic:1"
+                    decoded_st_field = f"uuid:{self.config.bridge_uid}"
                 response = (
                     self.upnp_device_response.format(device_type=decoded_st_field)
                     .replace("\n", "\r\n")

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -91,8 +91,8 @@ USN: {bridge_uuid}
                 ip_addr=config.ip_addr,
                 port_num=config.http_port,
                 bridge_id=config.bridge_id,
-                device_type="urn:schemas-upnp-org:device:basic:1",
-                # device_type=f"uuid:{config.bridge_uid}",
+                # device_type="urn:schemas-upnp-org:device:basic:1",
+                device_type=f"uuid:{config.bridge_uid}",
                 bridge_uuid=f"uuid:{config.bridge_uid}",
             )
             .replace("\n", "\r\n")

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -150,7 +150,7 @@ USN: {bridge_uuid}
                 # SSDP M-SEARCH method received, respond to it with our info
                 resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-                resp_socket.sendto(self.upnp_device_response, addr)
+                resp_socket.sendto(self.upnp_root_response, addr)
                 LOGGER.debug("Serving SSDP discovery info to %s", addr)
                 resp_socket.close()
 

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -142,6 +142,8 @@ USN: {bridge_uuid}
                     "(?<=\\r\\nST: )(.*)(?=\\r)", decoded_data
                 ).group(0)
                 if decoded_st_field == "ssdp:all":
+                    decoded_st_field = "urn:schemas-upnp-org:device:basic:1"
+                else:
                     decoded_st_field = f"uuid:{self.config.bridge_uid}"
                 response = (
                     self.upnp_device_response.format(device_type=decoded_st_field)

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -146,12 +146,12 @@ USN: {bridge_uuid}
                 # because the data object has not been initialized
                 continue
 
-            if "M-SEARCH" in data.decode("utf-8", errors="ignore"):
+            if "M-SEARCH" in (decoded_data := data.decode("utf-8", errors="ignore")):
                 # SSDP M-SEARCH method received, respond to it with our info
                 resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-                resp_socket.sendto(self.upnp_root_response, addr)
-                LOGGER.debug("Serving SSDP discovery info to %s", addr)
+                resp_socket.sendto(self.upnp_device_response, addr)
+                LOGGER.debug("Serving SSDP discovery info to %s with request %s", addr, repr(decoded_data))
                 resp_socket.close()
 
     def stop(self):

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -67,32 +67,33 @@ class UPNPResponderThread(threading.Thread):
         resp_template = """HTTP/1.1 200 OK
 CACHE-CONTROL: max-age=60
 EXT:
-LOCATION: http://{0}:{1}/description.xml
+LOCATION: http://{ip_addr}:{port_num}/description.xml
 SERVER: Linux/3.14.0 UPnP/1.0 IpBridge/1.20.0
-hue-bridgeid: {2}
-ST: {3}
-USN: uuid:{4}
+hue-bridgeid: {bridge_id}
+ST: {device_type}
+USN: {bridge_uuid}
 
 """
 
         self.upnp_root_response = (
             resp_template.format(
-                config.ip_addr,
-                config.http_port,
-                config.bridge_id,
-                "upnp:rootdevice",
-                f"{config.bridge_uid}::upnp:rootdevice",
+                ip_addr=config.ip_addr,
+                port_num=config.http_port,
+                bridge_id=config.bridge_id,
+                device_type="upnp:rootdevice",
+                bridge_uuid=f"uuid:{config.bridge_uid}::upnp:rootdevice",
             )
             .replace("\n", "\r\n")
             .encode("utf-8")
         )
         self.upnp_device_response = (
             resp_template.format(
-                config.ip_addr,
-                config.http_port,
-                config.bridge_id,
-                "urn:schemas-upnp-org:device:basic:1",
-                config.bridge_uid,
+                ip_addr=config.ip_addr,
+                port_num=config.http_port,
+                bridge_id=config.bridge_id,
+                # device_type="urn:schemas-upnp-org:device:basic:1",
+                device_type=f"uuid:{config.bridge_uid}",
+                bridge_uuid=f"uuid:{config.bridge_uid}",
             )
             .replace("\n", "\r\n")
             .encode("utf-8")
@@ -145,16 +146,16 @@ USN: uuid:{4}
                 # because the data object has not been initialized
                 continue
 
-            decoded_data = data.decode("utf-8", errors="ignore")
-            if "M-SEARCH" in decoded_data:
+            if "M-SEARCH" in (decoded_data := data.decode("utf-8", errors="ignore")):
                 # SSDP M-SEARCH method received, respond to it with our info
                 resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
                 if "upnp:rootdevice" in decoded_data:
                     resp_socket.sendto(self.upnp_root_response, addr)
+                    LOGGER.debug("Serving root SSDP discovery info to %s", addr)
                 else:
                     resp_socket.sendto(self.upnp_device_response, addr)
-                LOGGER.debug("Serving SSDP discovery info to %s", addr)
+                    LOGGER.debug("Serving device SSDP discovery info to %s", addr)
                 resp_socket.close()
 
     def stop(self):

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -91,8 +91,8 @@ USN: {bridge_uuid}
                 ip_addr=config.ip_addr,
                 port_num=config.http_port,
                 bridge_id=config.bridge_id,
-                # device_type="urn:schemas-upnp-org:device:basic:1",
-                device_type=f"uuid:{config.bridge_uid}",
+                device_type="urn:schemas-upnp-org:device:basic:1",
+                # device_type=f"uuid:{config.bridge_uid}",
                 bridge_uuid=f"uuid:{config.bridge_uid}",
             )
             .replace("\n", "\r\n")

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -95,7 +95,7 @@ USN: {bridge_uuid}
                     ip_addr=config.ip_addr,
                     port_num=config.http_port,
                     bridge_id=config.bridge_id,
-                    device_type=f"uuid:{config.bridge_uid}",
+                    device_type=f"uuid:{config.bridge_id}",
                     bridge_uuid=f"uuid:{config.bridge_uid}",
                 )
             )

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -95,7 +95,7 @@ USN: {bridge_uuid}
                     ip_addr=config.ip_addr,
                     port_num=config.http_port,
                     bridge_id=config.bridge_id,
-                    device_type=f"uuid:{config.bridge_id}",
+                    device_type=f"uuid:{config.bridge_uid}",
                     bridge_uuid=f"uuid:{config.bridge_uid}",
                 )
             )

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -146,16 +146,13 @@ USN: {bridge_uuid}
                 # because the data object has not been initialized
                 continue
 
-            if "M-SEARCH" in (decoded_data := data.decode("utf-8", errors="ignore")):
+            if "M-SEARCH" in data.decode("utf-8", errors="ignore"):
                 # SSDP M-SEARCH method received, respond to it with our info
                 resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-                if "upnp:rootdevice" in decoded_data:
-                    resp_socket.sendto(self.upnp_root_response, addr)
-                    LOGGER.debug("Serving root SSDP discovery info to %s", addr)
-                else:
-                    resp_socket.sendto(self.upnp_device_response, addr)
-                    LOGGER.debug("Serving device SSDP discovery info to %s", addr)
+                resp_socket.sendto(self.upnp_root_response, addr)
+                resp_socket.sendto(self.upnp_device_response, addr)
+                LOGGER.debug("Serving SSDP discovery info to %s", addr)
                 resp_socket.close()
 
     def stop(self):

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -149,7 +149,12 @@ USN: {bridge_uuid}
                     .encode("utf-8")
                 )
                 resp_socket.sendto(response, addr)
-                LOGGER.debug("Serving SSDP discovery info to %s", addr)
+                LOGGER.debug(
+                    "Serving SSDP discovery info to %s, received data %s, response data %s",
+                    addr,
+                    repr(decoded_data),
+                    repr(response),
+                )
                 resp_socket.close()
 
     def stop(self):

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -75,24 +75,12 @@ USN: {bridge_uuid}
 
 """
 
-        self.upnp_root_response = (
-            resp_template.format(
-                ip_addr=config.ip_addr,
-                port_num=config.http_port,
-                bridge_id=config.bridge_id,
-                device_type="upnp:rootdevice",
-                bridge_uuid=f"uuid:{config.bridge_uid}::upnp:rootdevice",
-            )
-            .replace("\n", "\r\n")
-            .encode("utf-8")
-        )
         self.upnp_device_response = (
             resp_template.format(
                 ip_addr=config.ip_addr,
                 port_num=config.http_port,
                 bridge_id=config.bridge_id,
                 device_type="urn:schemas-upnp-org:device:basic:1",
-                # device_type=f"uuid:{config.bridge_uid}",
                 bridge_uuid=f"uuid:{config.bridge_uid}",
             )
             .replace("\n", "\r\n")
@@ -146,12 +134,12 @@ USN: {bridge_uuid}
                 # because the data object has not been initialized
                 continue
 
-            if "M-SEARCH" in (decoded_data := data.decode("utf-8", errors="ignore")):
+            if "M-SEARCH" in data.decode("utf-8", errors="ignore"):
                 # SSDP M-SEARCH method received, respond to it with our info
                 resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
                 resp_socket.sendto(self.upnp_device_response, addr)
-                LOGGER.debug("Serving SSDP discovery info to %s with request %s", addr, repr(decoded_data))
+                LOGGER.debug("Serving SSDP discovery info to %s", addr)
                 resp_socket.close()
 
     def stop(self):

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -146,13 +146,16 @@ USN: {bridge_uuid}
                 # because the data object has not been initialized
                 continue
 
-            if "M-SEARCH" in data.decode("utf-8", errors="ignore"):
+            if "M-SEARCH" in (decoded_data := data.decode("utf-8", errors="ignore")):
                 # SSDP M-SEARCH method received, respond to it with our info
                 resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-                resp_socket.sendto(self.upnp_root_response, addr)
-                resp_socket.sendto(self.upnp_device_response, addr)
-                LOGGER.debug("Serving SSDP discovery info to %s", addr)
+                if "upnp:rootdevice" in decoded_data:
+                    resp_socket.sendto(self.upnp_root_response, addr)
+                    LOGGER.debug("Serving root SSDP discovery info to %s", addr)
+                else:
+                    resp_socket.sendto(self.upnp_device_response, addr)
+                    LOGGER.debug("Serving device SSDP discovery info to %s", addr)
                 resp_socket.close()
 
     def stop(self):

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -91,8 +91,8 @@ USN: {bridge_uuid}
                 ip_addr=config.ip_addr,
                 port_num=config.http_port,
                 bridge_id=config.bridge_id,
-                # device_type="urn:schemas-upnp-org:device:basic:1",
-                device_type=f"uuid:{config.bridge_uid}",
+                device_type="urn:schemas-upnp-org:device:basic:1",
+                # device_type=f"uuid:{config.bridge_uid}",
                 bridge_uuid=f"uuid:{config.bridge_uid}",
             )
             .replace("\n", "\r\n")
@@ -146,16 +146,12 @@ USN: {bridge_uuid}
                 # because the data object has not been initialized
                 continue
 
-            if "M-SEARCH" in (decoded_data := data.decode("utf-8", errors="ignore")):
+            if "M-SEARCH" in data.decode("utf-8", errors="ignore"):
                 # SSDP M-SEARCH method received, respond to it with our info
                 resp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-                if "upnp:rootdevice" in decoded_data:
-                    resp_socket.sendto(self.upnp_root_response, addr)
-                    LOGGER.debug("Serving root SSDP discovery info to %s", addr)
-                else:
-                    resp_socket.sendto(self.upnp_device_response, addr)
-                    LOGGER.debug("Serving device SSDP discovery info to %s", addr)
+                resp_socket.sendto(self.upnp_device_response, addr)
+                LOGGER.debug("Serving SSDP discovery info to %s", addr)
                 resp_socket.close()
 
     def stop(self):

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -144,7 +144,8 @@ USN: {bridge_uuid}
                 if decoded_st_field == "ssdp:all":
                     decoded_st_field = "urn:schemas-upnp-org:device:basic:1"
                 else:
-                    decoded_st_field = f"uuid:{self.config.bridge_uid}"
+                    # decoded_st_field = f"uuid:{self.config.bridge_uid}"
+                    decoded_st_field = "urn:schemas-upnp-org:device:basic:1"
                 response = (
                     self.upnp_device_response.format(device_type=decoded_st_field)
                     .replace("\n", "\r\n")

--- a/emulated_hue/utils.py
+++ b/emulated_hue/utils.py
@@ -26,6 +26,14 @@ LOCAL_NETWORKS = (
 )
 
 
+class Default(dict):
+    """Provide default strings for format."""
+
+    def __missing__(self, key):
+        """Append format string for missing keys."""
+        return "{" + key + "}"
+
+
 def is_local(address: Union[IPv4Address, IPv6Address]) -> bool:
     """Check if an address is local."""
     return address in LOCAL_IPS or any(address in network for network in LOCAL_NETWORKS)

--- a/emulated_hue/utils.py
+++ b/emulated_hue/utils.py
@@ -26,14 +26,6 @@ LOCAL_NETWORKS = (
 )
 
 
-class Default(dict):
-    """Provide default strings for format."""
-
-    def __missing__(self, key):
-        """Append format string for missing keys."""
-        return "{" + key + "}"
-
-
 def is_local(address: Union[IPv4Address, IPv6Address]) -> bool:
     """Check if an address is local."""
     return address in LOCAL_IPS or any(address in network for network in LOCAL_NETWORKS)


### PR DESCRIPTION
fixes pairing for Harmony mentioned in #110

This does not use the root device response that is seen in other Hue emulator examples. It does not seem to be necessary atm, but remains to be seen if another unreported device is not able to pair due to this being missing. 