### PR TITLE
Fix color_mode and states

### DIFF
--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -734,7 +734,7 @@ class HueApi:
         self, entity: dict, light_config: Optional[dict] = None
     ) -> dict:
         """Convert an entity to its Hue bridge JSON representation."""
-        entity_attr = entity_attributes_to_int(entity["attributes"])
+        entity_attr = entity_attributes_to_int(entity[const.HASS_ATTR])
         entity_color_modes = entity[const.HASS_ATTR].get(
             const.HASS_ATTR_SUPPORTED_COLOR_MODES, []
         )
@@ -751,7 +751,7 @@ class HueApi:
                 "mode": "homeautomation",
             },
             "name": light_config["name"]
-            or entity["attributes"].get("friendly_name", ""),
+            or entity[const.HASS_ATTR].get("friendly_name", ""),
             "uniqueid": light_config["uniqueid"],
             "swupdate": {
                 "state": "noupdates",

--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -979,10 +979,8 @@ class HueApi:
                         # set state of first light as group state
                         entity_obj = await self.__async_entity_to_hue(entity)
                         result[group_id]["action"] = entity_obj["state"]
-            if lights_on > 0:
-                result[group_id]["state"]["any_on"] = True
-            if lights_on == len(result[group_id]["lights"]):
-                result[group_id]["state"]["all_on"] = True
+            result[group_id]["state"]["any_on"] = lights_on > 0
+            result[group_id]["state"]["all_on"] = lights_on == len(result[group_id]["lights"])
             # do not return empty areas/rooms
             if len(result[group_id]["lights"]) == 0:
                 result.pop(group_id, None)

--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -980,7 +980,9 @@ class HueApi:
                         entity_obj = await self.__async_entity_to_hue(entity)
                         result[group_id]["action"] = entity_obj["state"]
             result[group_id]["state"]["any_on"] = lights_on > 0
-            result[group_id]["state"]["all_on"] = lights_on == len(result[group_id]["lights"])
+            result[group_id]["state"]["all_on"] = lights_on == len(
+                result[group_id]["lights"]
+            )
             # do not return empty areas/rooms
             if len(result[group_id]["lights"]) == 0:
                 result.pop(group_id, None)

--- a/emulated_hue/const.py
+++ b/emulated_hue/const.py
@@ -11,16 +11,32 @@ HASS_ATTR_EFFECT = "effect"
 HASS_ATTR_TRANSITION = "transition"
 HASS_ATTR_FLASH = "flash"
 
+# Deprecated Bitfield features
 HASS_SUPPORT_BRIGHTNESS = 1
 HASS_SUPPORT_COLOR_TEMP = 2
-HASS_SUPPORT_EFFECT = 4
-HASS_SUPPORT_FLASH = 8
+HASS_SUPPORT_EFFECT = 4  # unused
+HASS_SUPPORT_FLASH = 8  # unused
 HASS_SUPPORT_COLOR = 16
-HASS_SUPPORT_TRANSITION = 32
-HASS_SUPPORT_WHITE_VALUE = 128
+HASS_SUPPORT_TRANSITION = 32  # unused
+HASS_SUPPORT_WHITE_VALUE = 128  # unused
 
+# New color modes
+# https://github.com/home-assistant/core/blob/2b3148296c7af2dd381b48bd6c5aa2af5fdfac1b/homeassistant/components/light/__init__.py#L55
+HASS_COLOR_MODE_UNKNOWN = "unknown"  # Ambiguous color mode
+HASS_COLOR_MODE_ONOFF = "onoff"  # Must be the only supported mode
+HASS_COLOR_MODE_BRIGHTNESS = "brightness"  # Must be the only supported mode
+HASS_COLOR_MODE_COLOR_TEMP = "color_temp"
+HASS_COLOR_MODE_HS = "hs"
+HASS_COLOR_MODE_XY = "xy"
+HASS_COLOR_MODE_RGB = "rgb"
+HASS_COLOR_MODE_RGBW = "rgbw"
+HASS_COLOR_MODE_RGBWW = "rgbww"
+HASS_COLOR_MODE_WHITE = "white"  # Must *NOT* be the only supported mode
+
+HASS_ATTR = "attributes"
 HASS_ATTR_ENTITY_ID = "entity_id"
 HASS_ATTR_SUPPORTED_FEATURES = "supported_features"
+HASS_ATTR_SUPPORTED_COLOR_MODES = "supported_color_modes"
 HASS_SERVICE_TURN_OFF = "turn_off"
 HASS_SERVICE_TURN_ON = "turn_on"
 HASS_STATE_OFF = "off"

--- a/emulated_hue/const.py
+++ b/emulated_hue/const.py
@@ -53,6 +53,7 @@ HUE_ATTR_COLORMODE = "colormode"
 HUE_ATTR_HUE = "hue"
 HUE_ATTR_SAT = "sat"
 HUE_ATTR_CT = "ct"
+HUE_ATTR_HS = "hs"
 HUE_ATTR_XY = "xy"
 HUE_ATTR_EFFECT = "effect"
 HUE_ATTR_TRANSITION = "transitiontime"
@@ -67,3 +68,6 @@ HUE_ATTR_SAT_MIN = 0  # Saturation
 HUE_ATTR_SAT_MAX = 254
 HUE_ATTR_CT_MIN = 153  # Color temp
 HUE_ATTR_CT_MAX = 500
+
+HASS = "hass"
+HUE = "hue"

--- a/emulated_hue/utils.py
+++ b/emulated_hue/utils.py
@@ -156,6 +156,7 @@ def create_secure_string(length: int) -> str:
 
 
 def convert_color_mode(color_mode: str, intial_type: str) -> str:
+    """Convert color_mode names from initial_type to other type for xy, hs, and ct."""
     if intial_type == const.HASS:
         hass_color_modes = {
             const.HASS_COLOR_MODE_COLOR_TEMP: const.HUE_ATTR_CT,

--- a/emulated_hue/utils.py
+++ b/emulated_hue/utils.py
@@ -9,6 +9,7 @@ import socket
 from ipaddress import IPv4Address, IPv6Address, ip_address, ip_network
 from typing import Union
 
+import const
 import slugify as unicode_slug
 from aiohttp import web
 
@@ -152,3 +153,20 @@ def create_secure_string(length: int) -> str:
     """Create secure random string for username, client key, and tokens."""
     character_array = "ABCDEFabcdef0123456789"
     return "".join(random.SystemRandom().choice(character_array) for _ in range(length))
+
+
+def convert_color_mode(color_mode: str, intial_type: str) -> str:
+    if intial_type == const.HASS:
+        hass_color_modes = {
+            const.HASS_COLOR_MODE_COLOR_TEMP: const.HUE_ATTR_CT,
+            const.HASS_COLOR_MODE_XY: const.HUE_ATTR_XY,
+            const.HASS_COLOR_MODE_HS: const.HUE_ATTR_HS,
+        }
+        return hass_color_modes.get(color_mode, "xy")
+    else:
+        hue_color_modes = {
+            const.HUE_ATTR_CT: const.HASS_COLOR_MODE_COLOR_TEMP,
+            const.HUE_ATTR_XY: const.HASS_COLOR_MODE_XY,
+            const.HUE_ATTR_HS: const.HASS_COLOR_MODE_HS,
+        }
+        return hue_color_modes.get(color_mode, "xy")


### PR DESCRIPTION
fixes #177

color_mode was not being reported correctly after home-assistant/core#47720
This displays bulb types using the new supported_color_modes attribute.

Also corrects bug where states are not being correctly applied to rooms. 