### PR TITLE
Initiate link request on post only

### DIFF
--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -449,8 +449,6 @@ class HueApi:
         valid_user = True
         if not username or not await self.config.async_get_user(username):
             valid_user = False
-            # discovery config requested, enable discovery request
-            await self.config.async_enable_link_mode_discovery()
         result = await self.__async_get_bridge_config(full_details=valid_user)
         return send_json_response(result)
 


### PR DESCRIPTION
The link button procedure should only be initiated when there's a post to the api endpoint.
It's now also triggered on the get endpoint causing it to be triggered when zeroconf discovers this emulated bridge.

Fixes #242 