### PR TITLE
Fix doubled nesting of config in APIv1 output

### DIFF
--- a/emulated_hue/apiv1.py
+++ b/emulated_hue/apiv1.py
@@ -673,12 +673,10 @@ class HueApiV1Endpoints:
                 "lastinstall": datetime.datetime.now().isoformat().split(".")[0],
             },
             "config": {
-                "config": {
-                    "archetype": "sultanbulb",
-                    "direction": "omnidirectional",
-                    "function": "mixed",
-                    "startup": {"configured": True, "mode": "safety"},
-                }
+                "archetype": "sultanbulb",
+                "direction": "omnidirectional",
+                "function": "mixed",
+                "startup": {"configured": True, "mode": "safety"},
             },
         }
         current_state = {}


### PR DESCRIPTION
Fixes #399: Reduced doubled nesting config -> config in APIv1 output