### PR TITLE
Add advertise ip 

### DIFF
--- a/emulated_hue/__init__.py
+++ b/emulated_hue/__init__.py
@@ -16,13 +16,14 @@ class HueEmulator:
         data_path: str,
         hass_url: str,
         hass_token: str,
+        advertise_ip: str,
         http_port: int,
         https_port: int,
         use_default_ports: bool,
     ) -> None:
         """Create an instance of HueEmulator."""
         self.ctl: controllers.Controller | None = None
-        self._config_vars = (data_path, http_port, https_port, use_default_ports)
+        self._config_vars = (data_path, advertise_ip, http_port, https_port, use_default_ports)
         self._hass_url = hass_url
         self._hass_token = hass_token
         self._web: HueWeb | None = None

--- a/emulated_hue/__main__.py
+++ b/emulated_hue/__main__.py
@@ -55,6 +55,12 @@ if __name__ == "__main__":
         "--verbose", action="store_true", help="Enable more verbose logging"
     )
     parser.add_argument(
+        "--advertise-ip",
+        type=str,
+        help="If you need to override the IP address used for UPnP discovery. (For example, using network isolation in Docker)",
+        default=os.getenv("ADVERTISE_IP", ""),
+    )
+    parser.add_argument(
         "--http-port",
         type=int,
         help="Port to run the HTTP server (for use with reverse proxy, use with care)",
@@ -89,7 +95,7 @@ if __name__ == "__main__":
     logging.getLogger("hass_client").setLevel(logging.INFO)
 
     hue = HueEmulator(
-        datapath, url, token, args.http_port, args.https_port, use_default_ports
+        datapath, url, token, args.advertise_ip, args.http_port, args.https_port, use_default_ports
     )
 
     def on_shutdown(loop):

--- a/emulated_hue/__main__.py
+++ b/emulated_hue/__main__.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
         action="store_true",
         help=f"Always use HTTP port {const.HUE_HTTP_PORT} and HTTPS port {const.HUE_HTTPS_PORT} for discovery "
         f"regardless of actual exposed ports. Useful with reverse proxy.",
+        default=os.getenv("USE_DEFAULT_PORTS_FOR_DISCOVERY", "false"),
     )
 
     args = parser.parse_args()

--- a/emulated_hue/__main__.py
+++ b/emulated_hue/__main__.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
         action="store_true",
         help=f"Always use HTTP port {const.HUE_HTTP_PORT} and HTTPS port {const.HUE_HTTPS_PORT} for discovery "
         f"regardless of actual exposed ports. Useful with reverse proxy.",
-        default=os.getenv("USE_DEFAULT_PORTS_FOR_DISCOVERY", "false"),
     )
 
     args = parser.parse_args()

--- a/emulated_hue/apiv1.py
+++ b/emulated_hue/apiv1.py
@@ -513,9 +513,9 @@ class HueApiV1Endpoints:
     async def async_get_description(self, request: web.Request):
         """Serve the service description file."""
         resp_text = self._description_xml.format(
-            self.ctl.config_instance.ip_addr,
+            self.ctl.config_instance.advertise_addr,
             self.ctl.config_instance.http_port,
-            f"{self.ctl.config_instance.bridge_name} ({self.ctl.config_instance.ip_addr})",
+            f"{self.ctl.config_instance.bridge_name} ({self.ctl.config_instance.advertise_addr})",
             self.ctl.config_instance.bridge_serial,
             self.ctl.config_instance.bridge_uid,
         )

--- a/emulated_hue/apiv1.py
+++ b/emulated_hue/apiv1.py
@@ -929,8 +929,8 @@ class HueApiV1Endpoints:
             result.update(
                 {
                     "linkbutton": self.ctl.config_instance.link_mode_enabled,
-                    "ipaddress": self.ctl.config_instance.ip_addr,
-                    "gateway": self.ctl.config_instance.ip_addr,
+                    "ipaddress": self.ctl.config_instance.advertise_ip,
+                    "gateway": self.ctl.config_instance.advertise_ip,
                     "UTC": datetime.datetime.utcnow().isoformat().split(".")[0],
                     "localtime": datetime.datetime.now().isoformat().split(".")[0],
                     "timezone": self.ctl.config_instance.get_storage_value(

--- a/emulated_hue/apiv1.py
+++ b/emulated_hue/apiv1.py
@@ -513,9 +513,9 @@ class HueApiV1Endpoints:
     async def async_get_description(self, request: web.Request):
         """Serve the service description file."""
         resp_text = self._description_xml.format(
-            self.ctl.config_instance.advertise_addr,
+            self.ctl.config_instance.advertise_ip,
             self.ctl.config_instance.http_port,
-            f"{self.ctl.config_instance.bridge_name} ({self.ctl.config_instance.advertise_addr})",
+            f"{self.ctl.config_instance.bridge_name} ({self.ctl.config_instance.advertise_ip})",
             self.ctl.config_instance.bridge_serial,
             self.ctl.config_instance.bridge_uid,
         )

--- a/emulated_hue/controllers/__init__.py
+++ b/emulated_hue/controllers/__init__.py
@@ -9,7 +9,7 @@ from .scheduler import add_scheduler, remove_scheduler  # noqa
 
 
 async def async_start(
-    url, token, data_path, http_port, https_port, use_default_ports
+    url, token, data_path, advertise_ip, http_port, https_port, use_default_ports
 ) -> Controller:
     """Initialize all controllers."""
     ctl = Controller()
@@ -17,7 +17,7 @@ async def async_start(
     # the HA client is initialized in the async_start because it needs a running loop
     ctl.controller_hass = HomeAssistantController(url=url, token=token)
     ctl.config_instance = Config(
-        ctl, data_path, http_port, https_port, use_default_ports
+        ctl, data_path, advertise_ip, http_port, https_port, use_default_ports
     )
     await ctl.controller_hass.connect()
     return ctl

--- a/emulated_hue/controllers/config.py
+++ b/emulated_hue/controllers/config.py
@@ -53,12 +53,12 @@ class Config:
 
         # Get the IP address that will be passed to during discovery
         self._ip_addr = get_local_ip()
-        self._advertise_addr = self._ip_addr
+        self._advertise_ip = self._ip_addr
         LOGGER.info("Auto detected listen IP address is %s", self.ip_addr)
 
         if advertise_ip:
-            self._advertise_addr = advertise_ip
-            LOGGER.info("Use custom advertisement ip %s", self.advertise_addr)
+            self._advertise_ip = advertise_ip
+            LOGGER.info("Use custom advertisement ip %s", self.advertise_ip)
 
         # Get the ports that the Hue bridge will listen on
         # ports can be overridden but Hue apps expect ports 80/443
@@ -117,9 +117,9 @@ class Config:
         return self._ip_addr
 
     @property
-    def advertise_addr(self) -> str:
-        """Return advertise address of the emulated bridge."""
-        return self._advertise_addr
+    def advertise_ip(self) -> str:
+        """Return advertise ip address of the emulated bridge."""
+        return self._advertise_ip
 
     @property
     def mac_addr(self) -> str:
@@ -399,7 +399,7 @@ class Config:
         # create persistent notification in hass
         # user can click the link in the notification to enable linking
 
-        url = f"http://{self.advertise_addr}/link/{self._link_mode_discovery_key}"
+        url = f"http://{self.advertise_ip}/link/{self._link_mode_discovery_key}"
         msg = "Click the link below to enable pairing mode on the virtual bridge:\n\n"
         msg += f"**[Enable link mode]({url})**"
 

--- a/emulated_hue/controllers/config.py
+++ b/emulated_hue/controllers/config.py
@@ -399,7 +399,7 @@ class Config:
         # create persistent notification in hass
         # user can click the link in the notification to enable linking
 
-        url = f"http://{self.advertise_addr}:{self.http_port}/link/{self._link_mode_discovery_key}"
+        url = f"http://{self.advertise_addr}/link/{self._link_mode_discovery_key}"
         msg = "Click the link below to enable pairing mode on the virtual bridge:\n\n"
         msg += f"**[Enable link mode]({url})**"
 

--- a/emulated_hue/controllers/config.py
+++ b/emulated_hue/controllers/config.py
@@ -58,7 +58,7 @@ class Config:
 
         if advertise_ip:
             self._advertise_ip = advertise_ip
-            LOGGER.info("Use custom advertisement ip %s", self.advertise_ip)
+            LOGGER.info("Using custom advertisement ip %s", self.advertise_ip)
 
         # Get the ports that the Hue bridge will listen on
         # ports can be overridden but Hue apps expect ports 80/443

--- a/emulated_hue/controllers/config.py
+++ b/emulated_hue/controllers/config.py
@@ -388,7 +388,7 @@ class Config:
         # create persistent notification in hass
         # user can click the link in the notification to enable linking
 
-        url = f"http://{self.ip_addr}/link/{self._link_mode_discovery_key}"
+        url = f"http://{self.ip_addr}:{self.http_port}/link/{self._link_mode_discovery_key}"
         msg = "Click the link below to enable pairing mode on the virtual bridge:\n\n"
         msg += f"**[Enable link mode]({url})**"
 

--- a/emulated_hue/controllers/config.py
+++ b/emulated_hue/controllers/config.py
@@ -36,6 +36,7 @@ class Config:
         self,
         ctl: Controller,
         data_path: str,
+        advertise_ip: str,
         http_port: int,
         https_port: int,
         use_default_ports: bool,
@@ -52,7 +53,12 @@ class Config:
 
         # Get the IP address that will be passed to during discovery
         self._ip_addr = get_local_ip()
+        self._advertise_addr = self._ip_addr
         LOGGER.info("Auto detected listen IP address is %s", self.ip_addr)
+
+        if advertise_ip:
+            self._advertise_addr = advertise_ip
+            LOGGER.info("Use custom advertisement ip %s", self.advertise_addr)
 
         # Get the ports that the Hue bridge will listen on
         # ports can be overridden but Hue apps expect ports 80/443
@@ -109,6 +115,11 @@ class Config:
     def ip_addr(self) -> str:
         """Return ip address of the emulated bridge."""
         return self._ip_addr
+
+    @property
+    def advertise_addr(self) -> str:
+        """Return advertise address of the emulated bridge."""
+        return self._advertise_addr
 
     @property
     def mac_addr(self) -> str:
@@ -388,7 +399,7 @@ class Config:
         # create persistent notification in hass
         # user can click the link in the notification to enable linking
 
-        url = f"http://{self.ip_addr}:{self.http_port}/link/{self._link_mode_discovery_key}"
+        url = f"http://{self.advertise_addr}:{self.http_port}/link/{self._link_mode_discovery_key}"
         msg = "Click the link below to enable pairing mode on the virtual bridge:\n\n"
         msg += f"**[Enable link mode]({url})**"
 

--- a/emulated_hue/controllers/models.py
+++ b/emulated_hue/controllers/models.py
@@ -1,7 +1,7 @@
 """Device state model."""
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 from pydantic import BaseModel
 
@@ -34,7 +34,7 @@ class EntityState(BaseModel):
     transition_seconds: float | None = None
     brightness: int | None = None
     color_temp: int | None = None
-    hue_saturation: tuple[int, int] | None = None
+    hue_saturation: tuple[float, float] | None = None
     xy_color: tuple[float, float] | None = None
     rgb_color: tuple[int, int, int] | None = None
     flash_state: str | None = None

--- a/emulated_hue/controllers/models.py
+++ b/emulated_hue/controllers/models.py
@@ -1,7 +1,7 @@
 """Device state model."""
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 from pydantic import BaseModel
 
@@ -31,15 +31,15 @@ class EntityState(BaseModel):
 
     power_state: bool = True
     reachable: bool = True
-    transition_seconds: float | None = None
-    brightness: int | None = None
-    color_temp: int | None = None
-    hue_saturation: tuple[int, int] | None = None
-    xy_color: tuple[float, float] | None = None
-    rgb_color: tuple[int, int, int] | None = None
-    flash_state: str | None = None
-    effect: str | None = None
-    color_mode: str | None = None
+    transition_seconds: Optional[float] = None
+    brightness: Optional[int] = None
+    color_temp: Optional[int] = None
+    hue_saturation: Optional[Tuple[float, float]] = None
+    xy_color: Optional[Tuple[float, float]] = None
+    rgb_color: Optional[Tuple[int, int, int]] = None
+    flash_state: Optional[str] = None
+    effect: Optional[str] = None
+    color_mode: Optional[str] = None
 
     def __eq__(self, other):
         """Compare states."""
@@ -95,10 +95,10 @@ class EntityState(BaseModel):
             return EntityState()
 
         save_state = {}
-        for state in list(vars(cls).get("__fields__")):
+        for state in list(cls.model_fields):
             if state in save_state:
                 save_state[state] = states[state]
         return EntityState(**save_state)
 
 
-ALL_STATES: list = list(vars(EntityState).get("__fields__"))
+ALL_STATES: list = list(EntityState.model_fields)

--- a/emulated_hue/controllers/models.py
+++ b/emulated_hue/controllers/models.py
@@ -1,7 +1,7 @@
 """Device state model."""
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
@@ -31,15 +31,15 @@ class EntityState(BaseModel):
 
     power_state: bool = True
     reachable: bool = True
-    transition_seconds: Optional[float] = None
-    brightness: Optional[int] = None
-    color_temp: Optional[int] = None
-    hue_saturation: Optional[Tuple[float, float]] = None
-    xy_color: Optional[Tuple[float, float]] = None
-    rgb_color: Optional[Tuple[int, int, int]] = None
-    flash_state: Optional[str] = None
-    effect: Optional[str] = None
-    color_mode: Optional[str] = None
+    transition_seconds: float | None = None
+    brightness: int | None = None
+    color_temp: int | None = None
+    hue_saturation: tuple[int, int] | None = None
+    xy_color: tuple[float, float] | None = None
+    rgb_color: tuple[int, int, int] | None = None
+    flash_state: str | None = None
+    effect: str | None = None
+    color_mode: str | None = None
 
     def __eq__(self, other):
         """Compare states."""

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -65,7 +65,7 @@ class UPNPResponderThread(threading.Thread):
         threading.Thread.__init__(self)
         self.daemon = True
 
-        self.ip_addr = config.advertise_ip
+        self.ip_addr = config.ip_addr
         self.upnp_bind_multicast = bind_multicast
 
         # Note that the double newline at the end of

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -65,7 +65,7 @@ class UPNPResponderThread(threading.Thread):
         threading.Thread.__init__(self)
         self.daemon = True
 
-        self.ip_addr = config.ip_addr
+        self.ip_addr = config.advertise_ip
         self.upnp_bind_multicast = bind_multicast
 
         # Note that the double newline at the end of

--- a/emulated_hue/discovery.py
+++ b/emulated_hue/discovery.py
@@ -40,7 +40,7 @@ def start_zeroconf_discovery(config: Config):
     info = ServiceInfo(
         zeroconf_type,
         name=f"Philips Hue - {config.bridge_id[-6:]}.{zeroconf_type}",
-        addresses=[config.advertise_ip],
+        addresses=[get_ip_pton(config.advertise_ip)],
         port=443,
         properties={
             "bridgeid": config.bridge_id,

--- a/emulated_hue/utils.py
+++ b/emulated_hue/utils.py
@@ -61,12 +61,12 @@ def get_local_ip() -> str:
         sock.close()
 
 
-def get_ip_pton():
+def get_ip_pton(ip_addr: str):
     """Return socket pton for local ip."""
     try:
-        return socket.inet_pton(socket.AF_INET, get_local_ip())
+        return socket.inet_pton(socket.AF_INET, ip_addr)
     except OSError:
-        return socket.inet_pton(socket.AF_INET6, get_local_ip())
+        return socket.inet_pton(socket.AF_INET6, ip_addr)
 
 
 def slugify(text: str) -> str:


### PR DESCRIPTION
Hi, 

this PR enables the emulated hue to use a custom ip for advertisement together with some fixed for the custom port configuration.

My main goal for this changes is to use the emulated hue in kubernetes together with metallb.


Addresses the following issue:
https://github.com/hass-emulated-hue/core/issues/513
https://github.com/hass-emulated-hue/core/issues/514

Example of my config using the "app-template" helm chart (https://github.com/bjw-s/helm-charts/tree/main/charts/other/app-template)


```
controllers:
  ...
  hass-emulated-hue:
    enabled: true
    pod:
      hostNetwork: true   # needed for upnp and zeroconf
      affinity: 
        nodeAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 1
            preference:
              matchExpressions:
              - key: node-role.kubernetes.io/control-plane
                operator: DoesNotExist
    containers:
      main:
        env: 
          HASS_URL: h****
          HTTP_PORT: 6547
          HTTPS_PORT: 6548
          VERBOSE: "true"
          ADVERTISE_IP: 192.168.11.97
          USE_DEFAULT_PORTS_FOR_DISCOVERY: "true"
          DATA_DIR: /config
        envFrom:
          - secretRef:
              name: emulated-hue-secrets
        image: 
          repository: docker.io/eloo/hass-emulated-hue
          tag: 0.4.0-dev
        probes:
          liveness:
            enabled: false
          readiness:
            enabled: false
          startup:
            enabled: false
service:
  ...
  emulated-hue:
    controller: hass-emulated-hue
    enabled: true
    type: LoadBalancer
    annotations:
      metallb.universe.tf/ip-allocated-from-pool: emulated-hue-pool
    ports:
      hue-http:
        port: 80
        targetPort: 6547
      hue-https:
        port: 443
        targetPort: 6548
persistence:
  ...
  hass-emulated-hue:
    enabled: true
    type: persistentVolumeClaim
    name: hass-emulated-hue
    accessMode: ReadWriteOnce
    size: 100Mi
    storageClass: nfs-client-ssd        
    advancedMounts:
      hass-emulated-hue:
        main:
          - path: /config